### PR TITLE
chore(pre-commit): add ci: section for pre-commit.ci configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,13 @@
 # GNU General Public License
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+ci:
+  autofix_commit_msg: "chore(pre-commit): auto fixes from pre-commit.ci hooks"
+  autoupdate_commit_msg: "chore(pre-commit): update hook revisions"
+  autoupdate_schedule: weekly
+  skip:  # pip-audit: needs project deps installed; run locally
+  - pip-audit
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
## Summary

Adds a `ci:` section to `.pre-commit-config.yaml` to configure [pre-commit.ci](https://pre-commit.ci) now that the app is installed.

### Configuration added
- `autofix_commit_msg`: conventional-commits-formatted auto-fix message
- `autoupdate_commit_msg`: conventional-commits-formatted autoupdate message
- `autoupdate_schedule: weekly`: weekly hook revision updates
- See `skip:` entries in the file for any hooks skipped on CI

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>